### PR TITLE
Make image responsive (=work well on mobile phones)

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@ img {
 	border: grey solid 5px;
 	margin-left: auto;
 	margin-right: auto;
+	max-width:100px;
 }
 
 #LON {


### PR DESCRIPTION
By adding this declaration, the image will never be larger than the width of the screen: it will be shrunk on small screen, that is stay completely visible without scrolling.